### PR TITLE
Rename SSOGuard to TokenSSOGuard

### DIFF
--- a/Kernel/Auth/Guards/TokenSSOGuard.php
+++ b/Kernel/Auth/Guards/TokenSSOGuard.php
@@ -5,11 +5,13 @@ namespace Kernel\Auth\Guards;
 use Kernel\Adapters\Adapter;
 use Kernel\Contracts\Auth\Guard;
 
-class SSOGuard extends Adapter implements Guard
+class TokenSSOGuard extends Adapter implements Guard
 {
 
     public function getLoginUrl(){
-        return replacePlaceholders($this->config['login_url'], ['clientId'=>$this->config['client_id']]);
+        $loginUrl = get_option('my_sso_login_url');
+        $clientId = get_option('my_sso_client_id');
+        return replacePlaceholders($loginUrl, ['clientId' => $clientId]);
     }
     public function check(): bool
     {
@@ -53,8 +55,8 @@ class SSOGuard extends Adapter implements Guard
 
     public function attempt(array $credential)
     {
-        $api_url = $this->config['validate_url'];
-        $clientId = $this->config['client_id'];
+        $api_url = get_option('my_sso_validate_url');
+        $clientId = get_option('my_sso_client_id');
 
         appLogger(json_encode($credential));
         // Exchange code for token
@@ -143,10 +145,12 @@ class SSOGuard extends Adapter implements Guard
             return false;
         }
 
-        $response = wp_remote_post($this->config['validate_url'], [
+        $validateUrl = get_option('my_sso_validate_url');
+        $clientId = get_option('my_sso_client_id');
+        $response = wp_remote_post($validateUrl, [
             'body' => [
                 'grant_type' => 'refresh_token',
-                'client_id' => $this->config['client_id'],
+                'client_id' => $clientId,
                 'refresh_token' => $refreshToken,
             ],
         ]);

--- a/src/configs/adapters.php
+++ b/src/configs/adapters.php
@@ -6,10 +6,7 @@ return [
         'default' => 'sso',
         'contexts' => [
             'sso' => [
-                'context' => Kernel\Auth\Guards\SSOGuard::class,
-                'login_url' => 'https://tauth.platform.donap.ir/realms/donap/protocol/openid-connect/auth?client_id={clientId}&response_type=code',
-                'client_id' => 'market',
-                'validate_url'=>'https://tauth.platform.donap.ir/realms/donap/protocol/openid-connect/token'
+                'context' => Kernel\Auth\Guards\TokenSSOGuard::class,
             ]
         ]
     ],


### PR DESCRIPTION
## Summary
- rename the SSO auth guard to `TokenSSOGuard`
- reference `TokenSSOGuard` from the adapter config
- read SSO credentials from WordPress options instead of hardcoded values

## Testing
- `php -l Kernel/Auth/Guards/TokenSSOGuard.php`

------
https://chatgpt.com/codex/tasks/task_e_6867c4693aa88327a23a47fc732a9bef