### PR TITLE
Enhance SSO settings

### DIFF
--- a/src/Providers/PanelServiceProvider.php
+++ b/src/Providers/PanelServiceProvider.php
@@ -22,8 +22,11 @@ class PanelServiceProvider
                 );
         });
         Wordpress::action('admin_init',function(){
-            register_setting('my_sso_options_group', 'my_sso_token_endpoint');
+            register_setting('my_sso_options_group', 'my_sso_method');
+            register_setting('my_sso_options_group', 'my_sso_client_id');
+            register_setting('my_sso_options_group', 'my_sso_login_url');
             register_setting('my_sso_options_group', 'my_sso_secret_key');
+            register_setting('my_sso_options_group', 'my_sso_token_endpoint');
             register_setting('my_sso_options_group', 'my_sso_redirect_url');
         });
     }

--- a/views/pages/settings.view.php
+++ b/views/pages/settings.view.php
@@ -5,20 +5,63 @@
             <?php do_settings_sections('my_sso_options_group'); ?>
             <table class="form-table">
                 <tr valign="top">
-                    <th scope="row">Token Endpoint URL</th>
-                    <td><input type="text" name="my_sso_token_endpoint" value="<?php echo esc_attr(get_option('my_sso_token_endpoint')); ?>" style="width: 100%;"/></td>
+                    <th scope="row">SSO Method</th>
+                    <td>
+                        <select id="my_sso_method" name="my_sso_method">
+                            <option value="oauth" <?php selected(get_option('my_sso_method'), 'oauth'); ?>>OAuth 2.0</option>
+                            <option value="token" <?php selected(get_option('my_sso_method'), 'token'); ?>>Token Based</option>
+                        </select>
+                    </td>
                 </tr>
 
-                <tr valign="top">
+                <tr valign="top" class="oauth-fields">
+                    <th scope="row">Client ID</th>
+                    <td><input type="text" name="my_sso_client_id" value="<?php echo esc_attr(get_option('my_sso_client_id')); ?>" style="width: 100%;"/></td>
+                </tr>
+
+                <tr valign="top" class="oauth-fields">
+                    <th scope="row">Login URL</th>
+                    <td><input type="text" name="my_sso_login_url" value="<?php echo esc_attr(get_option('my_sso_login_url')); ?>" style="width: 100%;"/></td>
+                </tr>
+
+                <tr valign="top" class="oauth-fields">
                     <th scope="row">Secret Key</th>
                     <td><input type="text" name="my_sso_secret_key" value="<?php echo esc_attr(get_option('my_sso_secret_key')); ?>" style="width: 100%;"/></td>
                 </tr>
 
-                <tr valign="top">
+                <tr valign="top" class="token-fields">
+                    <th scope="row">Token Endpoint URL</th>
+                    <td><input type="text" name="my_sso_token_endpoint" value="<?php echo esc_attr(get_option('my_sso_token_endpoint')); ?>" style="width: 100%;"/></td>
+                </tr>
+
+                <tr valign="top" class="token-fields">
+                    <th scope="row">Secret Key</th>
+                    <td><input type="text" name="my_sso_secret_key" value="<?php echo esc_attr(get_option('my_sso_secret_key')); ?>" style="width: 100%;"/></td>
+                </tr>
+
+                <tr valign="top" class="token-fields">
                     <th scope="row">Redirect URL (after login)</th>
                     <td><input type="text" name="my_sso_redirect_url" value="<?php echo esc_attr(get_option('my_sso_redirect_url')); ?>" style="width: 100%;"/></td>
                 </tr>
             </table>
             <?php submit_button(); ?>
         </form>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const select = document.getElementById('my_sso_method');
+                function toggleFields() {
+                    const method = select.value;
+                    document.querySelectorAll('.oauth-fields').forEach(el => {
+                        el.style.display = method === 'oauth' ? '' : 'none';
+                    });
+                    document.querySelectorAll('.token-fields').forEach(el => {
+                        el.style.display = method === 'token' ? '' : 'none';
+                    });
+                }
+                if (select) {
+                    select.addEventListener('change', toggleFields);
+                    toggleFields();
+                }
+            });
+        </script>
     </div>


### PR DESCRIPTION
## Summary
- add new options in `PanelServiceProvider` for choosing SSO method
- extend settings page to configure OAuth or Token-based SSO
- show/hide fields dynamically based on selected method

## Testing
- `php -l src/Providers/PanelServiceProvider.php`
- `php -l views/pages/settings.view.php`


------
https://chatgpt.com/codex/tasks/task_e_6867c48d21bc832789a9ec29c6e73b3b