### PR TITLE
Improve SSO settings and guards

### DIFF
--- a/Kernel/Auth/Guards/PasswordSSOGuard.php
+++ b/Kernel/Auth/Guards/PasswordSSOGuard.php
@@ -9,7 +9,7 @@ class PasswordSSOGuard extends Adapter implements Guard
 {
     public function getLoginUrl()
     {
-        return get_option('my_sso_redirect_url');
+        return $this->config['redirect_url'] ?? home_url();
     }
 
     public function check(): bool
@@ -25,7 +25,10 @@ class PasswordSSOGuard extends Adapter implements Guard
         return false;
     }
 
-    public function user() {}
+    public function user() {
+        $user = wp_get_current_user();
+        return ($user && $user->ID) ? $user : null;
+    }
 
     public function login($user)
     {
@@ -40,14 +43,15 @@ class PasswordSSOGuard extends Adapter implements Guard
             delete_user_meta($user->ID, 'sso_access_token');
             delete_user_meta($user->ID, 'sso_refresh_token');
             delete_user_meta($user->ID, 'sso_expires_at');
+            $this->revokeToken($user);
         }
         wp_logout();
     }
 
     public function attempt(array $credential)
     {
-        $apiUrl = get_option('my_sso_token_endpoint');
-        $secret = get_option('my_sso_secret_key');
+        $apiUrl = $this->config['token_endpoint'] ?? '';
+        $secret = $this->config['secret_key'] ?? '';
 
         $response = wp_remote_post($apiUrl, [
             'body' => [
@@ -110,6 +114,7 @@ class PasswordSSOGuard extends Adapter implements Guard
         }
 
         $this->login($user);
+        $this->getUserInfo($user);
         return $user;
     }
 
@@ -120,10 +125,10 @@ class PasswordSSOGuard extends Adapter implements Guard
             return false;
         }
 
-        $response = wp_remote_post(get_option('my_sso_token_endpoint'), [
+        $response = wp_remote_post($this->config['token_endpoint'] ?? '', [
             'body' => [
                 'grant_type' => 'refresh_token',
-                'client_secret' => get_option('my_sso_secret_key'),
+                'client_secret' => $this->config['secret_key'] ?? '',
                 'refresh_token' => $refreshToken,
             ],
         ]);
@@ -150,7 +155,48 @@ class PasswordSSOGuard extends Adapter implements Guard
         if (count($parts) !== 3) {
             return null;
         }
-        $payload = base64_decode(strtr($parts[1], '-_', '+/'));
+
+        $header    = json_decode(base64_decode(strtr($parts[0], '-_', '+/')), true);
+        $payload   = base64_decode(strtr($parts[1], '-_', '+/'));
+        $signature = base64_decode(strtr($parts[2], '-_', '+/'));
+
+        if (!empty($this->config['public_key'])) {
+            $data  = $parts[0] . '.' . $parts[1];
+            $pub   = openssl_pkey_get_public($this->config['public_key']);
+            if (!$pub || openssl_verify($data, $signature, $pub, OPENSSL_ALGO_SHA256) !== 1) {
+                return null;
+            }
+        }
+
         return json_decode($payload, true);
+    }
+
+    public function getUserInfo($user)
+    {
+        $url = $this->config['user_info_url'] ?? '';
+        if (!$url) {
+            return null;
+        }
+        $token = get_user_meta($user->ID, 'sso_access_token', true);
+        $resp = wp_remote_get($url, [
+            'headers' => [ 'Authorization' => 'Bearer ' . $token ],
+        ]);
+        if (is_wp_error($resp)) {
+            return null;
+        }
+        return json_decode(wp_remote_retrieve_body($resp), true);
+    }
+
+    public function revokeToken($user)
+    {
+        $logoutUrl = $this->config['logout_url'] ?? '';
+        if (!$logoutUrl) {
+            return;
+        }
+        $token = get_user_meta($user->ID, 'sso_refresh_token', true);
+        if (!$token) {
+            return;
+        }
+        wp_remote_post($logoutUrl, ['body' => ['token' => $token]]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,9 +16,15 @@ It provides a token-based login adapter and a simple admin interface for configu
 
 After activation a new **SSO Settings** page appears under **Settings**. Fill in the following fields:
 
-1. **Token Endpoint URL** – the URL used to exchange the authorization code for access tokens.
-2. **Secret Key** – the client secret for your SSO provider.
-3. **Redirect URL (after login)** – where users should be redirected once authenticated.
+1. **Client ID** – OAuth client identifier.
+2. **Login URL** – authorization endpoint of the SSO provider.
+3. **Validate URL** – endpoint used to exchange the authorization code for tokens.
+4. **Token Endpoint URL** – password or client credentials token endpoint.
+5. **Secret Key** – the client secret for your SSO provider.
+6. **Redirect URL** – where users should be redirected once authenticated.
+7. **Logout URL** – optional single logout endpoint.
+8. **Public Key** – RSA public key used to verify JWT signatures.
+9. **User Info URL** – endpoint returning additional profile information.
 
 Save the changes to update the stored options.
 
@@ -32,10 +38,12 @@ return [
         'default' => 'sso',
         'contexts' => [
             'sso' => [
-                'context' => Kernel\Auth\Guards\SSOGuard::class,
-                'login_url' => 'https://tauth.platform.donap.ir/realms/donap/protocol/openid-connect/auth?client_id={clientId}&response_type=code',
-                'client_id' => 'market',
-                'validate_url' => 'https://tauth.platform.donap.ir/realms/donap/protocol/openid-connect/token'
+                'context'       => Kernel\Auth\Guards\TokenSSOGuard::class,
+                'login_url'     => get_option('my_sso_login_url'),
+                'client_id'     => get_option('my_sso_client_id'),
+                'validate_url'  => get_option('my_sso_validate_url'),
+                'redirect_url'  => get_option('my_sso_redirect_url'),
+                'public_key'    => get_option('my_sso_public_key'),
             ]
         ]
     ],
@@ -46,10 +54,11 @@ To introduce another SSO provider, add a new context to the `contexts` array and
 
 ```php
 'another' => [
-    'context'     => Kernel\Auth\Guards\SSOGuard::class,
-    'login_url'   => 'https://example.com/auth?client_id={clientId}&response_type=code',
-    'client_id'   => 'my-client',
-    'validate_url'=> 'https://example.com/token',
+    'context'       => Kernel\Auth\Guards\TokenSSOGuard::class,
+    'login_url'     => get_option('another_login_url'),
+    'client_id'     => get_option('another_client_id'),
+    'validate_url'  => get_option('another_validate_url'),
+    'redirect_url'  => get_option('another_redirect_url'),
 ],
 ```
 

--- a/src/Providers/PanelServiceProvider.php
+++ b/src/Providers/PanelServiceProvider.php
@@ -22,13 +22,16 @@ class PanelServiceProvider
                 );
         });
         Wordpress::action('admin_init',function(){
-            register_setting('my_sso_options_group', 'my_sso_method');
-            register_setting('my_sso_options_group', 'my_sso_client_id');
-            register_setting('my_sso_options_group', 'my_sso_login_url');
-            register_setting('my_sso_options_group', 'my_sso_secret_key');
-            register_setting('my_sso_options_group', 'my_sso_token_endpoint');
-            register_setting('my_sso_options_group', 'my_sso_redirect_url');
-            register_setting('my_sso_options_group', 'my_sso_method');
+            register_setting('my_sso_options_group', 'my_sso_method', ['sanitize_callback' => 'sanitize_text_field']);
+            register_setting('my_sso_options_group', 'my_sso_client_id', ['sanitize_callback' => 'sanitize_text_field']);
+            register_setting('my_sso_options_group', 'my_sso_login_url', ['sanitize_callback' => 'esc_url_raw']);
+            register_setting('my_sso_options_group', 'my_sso_secret_key', ['sanitize_callback' => 'sanitize_text_field']);
+            register_setting('my_sso_options_group', 'my_sso_token_endpoint', ['sanitize_callback' => 'esc_url_raw']);
+            register_setting('my_sso_options_group', 'my_sso_redirect_url', ['sanitize_callback' => 'esc_url_raw']);
+            register_setting('my_sso_options_group', 'my_sso_validate_url', ['sanitize_callback' => 'esc_url_raw']);
+            register_setting('my_sso_options_group', 'my_sso_logout_url', ['sanitize_callback' => 'esc_url_raw']);
+            register_setting('my_sso_options_group', 'my_sso_public_key');
+            register_setting('my_sso_options_group', 'my_sso_userinfo_url', ['sanitize_callback' => 'esc_url_raw']);
         });
     }
 }

--- a/src/configs/adapters.php
+++ b/src/configs/adapters.php
@@ -6,16 +6,32 @@ return [
         'default' => 'sso',
         'contexts' => [
             'sso' => [
-                'context' => Kernel\Auth\Guards\TokenSSOGuard::class,
-                'login_url' => 'https://tauth.platform.donap.ir/realms/donap/protocol/openid-connect/auth?client_id={clientId}&response_type=code',
-                'client_id' => 'market',
-                'validate_url'=>'https://tauth.platform.donap.ir/realms/donap/protocol/openid-connect/token'
+                'context'       => Kernel\Auth\Guards\TokenSSOGuard::class,
+                'login_url'     => get_option('my_sso_login_url'),
+                'client_id'     => get_option('my_sso_client_id'),
+                'validate_url'  => get_option('my_sso_validate_url'),
+                'redirect_url'  => get_option('my_sso_redirect_url'),
+                'public_key'    => get_option('my_sso_public_key'),
+                'logout_url'    => get_option('my_sso_logout_url'),
+                'user_info_url' => get_option('my_sso_userinfo_url'),
             ],
             'password' => [
-                'context' => Kernel\Auth\Guards\PasswordSSOGuard::class,
+                'context'        => Kernel\Auth\Guards\PasswordSSOGuard::class,
+                'token_endpoint' => get_option('my_sso_token_endpoint'),
+                'secret_key'     => get_option('my_sso_secret_key'),
+                'redirect_url'   => get_option('my_sso_redirect_url'),
+                'public_key'     => get_option('my_sso_public_key'),
+                'logout_url'     => get_option('my_sso_logout_url'),
+                'user_info_url'  => get_option('my_sso_userinfo_url'),
             ],
             'secret' => [
-                'context' => Kernel\Auth\Guards\SecretKeySSOGuard::class,
+                'context'        => Kernel\Auth\Guards\SecretKeySSOGuard::class,
+                'token_endpoint' => get_option('my_sso_token_endpoint'),
+                'secret_key'     => get_option('my_sso_secret_key'),
+                'redirect_url'   => get_option('my_sso_redirect_url'),
+                'public_key'     => get_option('my_sso_public_key'),
+                'logout_url'     => get_option('my_sso_logout_url'),
+                'user_info_url'  => get_option('my_sso_userinfo_url'),
             ]
         ]
     ],

--- a/views/pages/settings.view.php
+++ b/views/pages/settings.view.php
@@ -1,68 +1,76 @@
 <div class="wrap">
-        <h1>SSO Settings</h1>
-        <form method="post" action="options.php">
-            <?php settings_fields('my_sso_options_group'); ?>
-            <?php do_settings_sections('my_sso_options_group'); ?>
-            <table class="form-table">
-
-                <tr valign="top">
-                  
-                    <td>
-                        <select id="my_sso_method" name="my_sso_method">
-                            <option value="oauth" <?php selected(get_option('my_sso_method'), 'oauth'); ?>>OAuth 2.0</option>
-                            <option value="token" <?php selected(get_option('my_sso_method'), 'token'); ?>>Token Based</option>
-                        </select>
-                    </td>
-                </tr>
-
-                <tr valign="top" class="oauth-fields">
-                    <th scope="row">Client ID</th>
-                    <td><input type="text" name="my_sso_client_id" value="<?php echo esc_attr(get_option('my_sso_client_id')); ?>" style="width: 100%;"/></td>
-                </tr>
-
-                <tr valign="top" class="oauth-fields">
-                    <th scope="row">Login URL</th>
-                    <td><input type="text" name="my_sso_login_url" value="<?php echo esc_attr(get_option('my_sso_login_url')); ?>" style="width: 100%;"/></td>
-                </tr>
-
-                <tr valign="top" class="oauth-fields">
-                    <th scope="row">Secret Key</th>
-                    <td><input type="text" name="my_sso_secret_key" value="<?php echo esc_attr(get_option('my_sso_secret_key')); ?>" style="width: 100%;"/></td>
-                </tr>
-
-                <tr valign="top" class="token-fields">
-                    <th scope="row">Token Endpoint URL</th>
-                    <td><input type="text" name="my_sso_token_endpoint" value="<?php echo esc_attr(get_option('my_sso_token_endpoint')); ?>" style="width: 100%;"/></td>
-                </tr>
-
-                <tr valign="top" class="token-fields">
-                    <th scope="row">Secret Key</th>
-                    <td><input type="text" name="my_sso_secret_key" value="<?php echo esc_attr(get_option('my_sso_secret_key')); ?>" style="width: 100%;"/></td>
-                </tr>
-
-                <tr valign="top" class="token-fields">
-                    <th scope="row">Redirect URL (after login)</th>
-                    <td><input type="text" name="my_sso_redirect_url" value="<?php echo esc_attr(get_option('my_sso_redirect_url')); ?>" style="width: 100%;"/></td>
-                </tr>
-            </table>
-            <?php submit_button(); ?>
-        </form>
-        <script>
-            document.addEventListener('DOMContentLoaded', function () {
-                const select = document.getElementById('my_sso_method');
-                function toggleFields() {
-                    const method = select.value;
-                    document.querySelectorAll('.oauth-fields').forEach(el => {
-                        el.style.display = method === 'oauth' ? '' : 'none';
-                    });
-                    document.querySelectorAll('.token-fields').forEach(el => {
-                        el.style.display = method === 'token' ? '' : 'none';
-                    });
-                }
-                if (select) {
-                    select.addEventListener('change', toggleFields);
-                    toggleFields();
-                }
-            });
-        </script>
-    </div>
+    <h1>SSO Settings</h1>
+    <form method="post" action="options.php">
+        <?php settings_fields('my_sso_options_group'); ?>
+        <?php do_settings_sections('my_sso_options_group'); ?>
+        <table class="form-table">
+            <tr valign="top">
+                <td>
+                    <select id="my_sso_method" name="my_sso_method">
+                        <option value="oauth" <?php selected(get_option('my_sso_method'), 'oauth'); ?>>OAuth 2.0</option>
+                        <option value="token" <?php selected(get_option('my_sso_method'), 'token'); ?>>Token Based</option>
+                    </select>
+                </td>
+            </tr>
+            <tr valign="top" class="oauth-fields">
+                <th scope="row">Client ID</th>
+                <td><input type="text" name="my_sso_client_id" value="<?php echo esc_attr(get_option('my_sso_client_id')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top" class="oauth-fields">
+                <th scope="row">Login URL</th>
+                <td><input type="text" name="my_sso_login_url" value="<?php echo esc_attr(get_option('my_sso_login_url')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top" class="oauth-fields">
+                <th scope="row">Validate URL</th>
+                <td><input type="text" name="my_sso_validate_url" value="<?php echo esc_attr(get_option('my_sso_validate_url')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top" class="oauth-fields">
+                <th scope="row">Secret Key</th>
+                <td><input type="text" name="my_sso_secret_key" value="<?php echo esc_attr(get_option('my_sso_secret_key')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top" class="token-fields">
+                <th scope="row">Token Endpoint URL</th>
+                <td><input type="text" name="my_sso_token_endpoint" value="<?php echo esc_attr(get_option('my_sso_token_endpoint')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top" class="token-fields">
+                <th scope="row">Secret Key</th>
+                <td><input type="text" name="my_sso_secret_key" value="<?php echo esc_attr(get_option('my_sso_secret_key')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top">
+                <th scope="row">Redirect URL (after login)</th>
+                <td><input type="text" name="my_sso_redirect_url" value="<?php echo esc_attr(get_option('my_sso_redirect_url')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top">
+                <th scope="row">Logout URL</th>
+                <td><input type="text" name="my_sso_logout_url" value="<?php echo esc_attr(get_option('my_sso_logout_url')); ?>" style="width: 100%;" /></td>
+            </tr>
+            <tr valign="top">
+                <th scope="row">Public Key</th>
+                <td><textarea name="my_sso_public_key" rows="4" style="width: 100%;"><?php echo esc_textarea(get_option('my_sso_public_key')); ?></textarea></td>
+            </tr>
+            <tr valign="top">
+                <th scope="row">User Info URL</th>
+                <td><input type="text" name="my_sso_userinfo_url" value="<?php echo esc_attr(get_option('my_sso_userinfo_url')); ?>" style="width: 100%;" /></td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const select = document.getElementById('my_sso_method');
+            function toggleFields() {
+                const method = select.value;
+                document.querySelectorAll('.oauth-fields').forEach(el => {
+                    el.style.display = method === 'oauth' ? '' : 'none';
+                });
+                document.querySelectorAll('.token-fields').forEach(el => {
+                    el.style.display = method === 'token' ? '' : 'none';
+                });
+            }
+            if (select) {
+                select.addEventListener('change', toggleFields);
+                toggleFields();
+            }
+        });
+    </script>
+</div>


### PR DESCRIPTION
## Summary
- sanitize and expand SSO settings
- load wp options in adapter config
- implement complete guard methods
- support token validation and user info retrieval
- add single logout logic

## Testing
- `php` binary not available, so PHP lint could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6867cdc7a7908327b455c59cb310188f