### PR TITLE
Add SSO user page and audit log docs

### DIFF
--- a/Kernel/Auth/Guards/TokenSSOGuard.php
+++ b/Kernel/Auth/Guards/TokenSSOGuard.php
@@ -145,9 +145,17 @@ class TokenSSOGuard extends Adapter implements Guard
             update_user_meta($user_id, 'sso_national_id', $body['nationalId']);
 
             $user = get_user_by('id', $user_id);
+
+            if(function_exists('yekta_audit_log')){
+                yekta_audit_log($user_id, 'created');
+            }
         }
 
         $this->login($user);
+
+        if(function_exists('yekta_audit_log')){
+            yekta_audit_log($user->ID, 'login');
+        }
         $this->getUserInfo($user);
 
         return $user;

--- a/README.md
+++ b/README.md
@@ -1,36 +1,45 @@
-# Yekta WordPress Plugin
+# افزونه وردپرس یکتا
 
-This plugin integrates Yekta SSO authentication with WordPress.
-It provides a token-based login adapter and a simple admin interface for configuring SSO endpoints.
+این افزونه امکان اتصال سامانه Single Sign-On (SSO) یکتا به وردپرس را فراهم می‌کند. پس از فعال‌سازی می‌توانید تنظیمات سرویس را در بخش «تنظیمات SSO» انجام دهید.
 
-## Installation
+## نصب
 
-1. Copy or clone the plugin folder into `wp-content/plugins/sso-wp` so that `sso-wp.php` is located directly inside the directory.
-2. (Optional) Launch the provided Docker setup for a local test environment using:
+1. پوشه افزونه را در مسیر `wp-content/plugins/sso-wp` کپی کنید به طوری که فایل `sso-wp.php` مستقیماً داخل آن قرار گیرد.
+2. (اختیاری) برای راه‌اندازی محیط تست محلی می‌توانید از Docker استفاده کنید:
    ```bash
    docker compose up
    ```
-3. Activate **Yekta** from the WordPress **Plugins** page.
+3. سپس افزونه **یکتا** را از بخش **Plugins** فعال کنید.
 
-## Configuring SSO
+## تنظیمات
 
-After activation a new **SSO Settings** page appears under **Settings**. Fill in the following fields:
+در منوی مدیریت وردپرس صفحه‌ای با عنوان «تنظیمات SSO» افزوده می‌شود. فیلدهای زیر را بر اساس اطلاعات سرویس دهنده پر کنید:
 
-1. **Client ID** – OAuth client identifier for the authorization code flow.
-2. **Login URL** – authorization endpoint of the SSO provider.
-3. **Validate URL** – endpoint used to exchange the authorization code for tokens.
-4. **Token Endpoint URL** – password or client credentials token endpoint.
-5. **Secret Key** – the client secret for your SSO provider.
-6. **Redirect URL** – where users should be redirected once authenticated.
-7. **Logout URL** – optional single logout endpoint.
-8. **Public Key** – RSA public key used to verify JWT signatures.
-9. **User Info URL** – endpoint returning additional profile information.
+1. شناسه کلاینت
+2. آدرس ورود
+3. آدرس اعتبارسنجی
+4. آدرس دریافت توکن
+5. کلید مخفی
+6. آدرس بازگشت پس از ورود
+7. آدرس خروج
+8. کلید عمومی
+9. آدرس اطلاعات کاربر
 
-Save the changes to update the stored options.
+با ذخیره تنظیمات مقادیر در وردپرس ذخیره می‌شوند.
 
-## Adapter settings
+## مدیریت کاربران
 
-Underlying SSO behaviour is configured in `src/configs/adapters.php`. Three guards are available (`token`, `password` and `secret`). The default adapter is token based and defined as:
+صفحه دیگری با عنوان «کاربران SSO» در منو ایجاد شده است. در این صفحه تمام کاربرانی که دارای فیلد `sso_global_id` هستند با صفحه‌بندی بیست‌تایی نمایش داده می‌شوند. بالای صفحه آمار امروز شامل تعداد ورودها و کاربران جدید مشاهده می‌شود.
+
+با کلیک روی دکمه «نمایش اطلاعات» مقابل هر کاربر، جزئیات تکمیلی کاربر از آدرس `User Info URL` خوانده شده و در یک پنجره کوچک نمایش داده می‌شود.
+
+## ثبت رویدادها
+
+هنگام فعال‌سازی افزونه، جدولی با نام `yekta_audit` در پایگاه داده ساخته می‌شود که شامل ستون‌های `id`، `user_id`، `type`، `created_at` و `params` است. ورود و ایجاد کاربران در این جدول ثبت می‌شود و برای نمایش آمار در صفحه کاربران استفاده می‌شود.
+
+## تغییر آداپتور
+
+پیکربندی نگهدارنده ورود در فایل `src/configs/adapters.php` قرار دارد. سه روش `token`، `password` و `secret` وجود دارد که می‌توانید مقدار پیش‌فرض را تغییر دهید.
 
 ```php
 return [
@@ -50,16 +59,4 @@ return [
 ];
 ```
 
-To introduce another SSO provider, add a new context to the `contexts` array and change the `default` key. Example:
-
-```php
-'another' => [
-    'context'       => Kernel\Auth\Guards\TokenSSOGuard::class,
-    'login_url'     => get_option('another_login_url'),
-    'client_id'     => get_option('another_client_id'),
-    'validate_url'  => get_option('another_validate_url'),
-    'redirect_url'  => get_option('another_redirect_url'),
-],
-```
-
-Set `'default' => 'another'` to make it active.
+در صورت نیاز می‌توانید کانتکست جدیدی افزوده و مقدار `default` را تغییر دهید.

--- a/src/Helpers/helper.php
+++ b/src/Helpers/helper.php
@@ -76,3 +76,16 @@ if(!function_exists('get_sso_user_id')){
     }
 }
 
+
+if(!function_exists('yekta_audit_log')){
+    function yekta_audit_log($user_id, $type, $params = null){
+        global $wpdb;
+        $table = $wpdb->prefix . 'yekta_audit';
+        $wpdb->insert($table,[
+            'user_id' => $user_id,
+            'type' => $type,
+            'params' => $params ? wp_json_encode($params) : null,
+            'created_at' => current_time('mysql')
+        ]);
+    }
+}

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -10,8 +10,19 @@ class AppServiceProvider
     {
         global $wpdb;
 
+        $table_name = $wpdb->prefix . 'yekta_audit';
+        $charset_collate = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT(20) UNSIGNED NOT NULL,
+            type VARCHAR(50) NOT NULL,
+            params LONGTEXT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY user_id (user_id)
+        ) $charset_collate;";
+        dbDelta($sql);
 
-        
     }
 
 

--- a/views/pages/settings.view.php
+++ b/views/pages/settings.view.php
@@ -1,5 +1,5 @@
 <div class="wrap">
-    <h1>SSO Settings</h1>
+    <h1>تنظیمات SSO</h1>
     <form method="post" action="options.php">
         <?php settings_fields('yekta_sso_options_group'); ?>
         <?php do_settings_sections('yekta_sso_options_group'); ?>
@@ -7,86 +7,86 @@
             <tr valign="top">
                 <td>
                     <select id="yekta_sso_method" name="yekta_sso_method">
-                        <option value="token" <?php selected(get_option('yekta_sso_method'), 'token'); ?>>Authorization Code</option>
-                        <option value="password" <?php selected(get_option('yekta_sso_method'), 'password'); ?>>Password</option>
-                        <option value="secret" <?php selected(get_option('yekta_sso_method'), 'secret'); ?>>Secret Key</option>
+                        <option value="token" <?php selected(get_option('yekta_sso_method'), 'token'); ?>>کد مجوز</option>
+                        <option value="password" <?php selected(get_option('yekta_sso_method'), 'password'); ?>>رمز عبور</option>
+                        <option value="secret" <?php selected(get_option('yekta_sso_method'), 'secret'); ?>>کلید مخفی</option>
                     </select>
                 </td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">Client ID</th>
+                <th scope="row">شناسه کلاینت</th>
                 <td><input type="text" name="yekta_sso_token_guard_client_id" value="<?php echo esc_attr(get_option('yekta_sso_token_guard_client_id')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">Login URL</th>
+                <th scope="row">آدرس ورود</th>
                 <td><input type="text" name="yekta_sso_token_guard_login_url" value="<?php echo esc_attr(get_option('yekta_sso_token_guard_login_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">Validate URL</th>
+                <th scope="row">آدرس اعتبارسنجی</th>
                 <td><input type="text" name="yekta_sso_token_guard_validate_url" value="<?php echo esc_attr(get_option('yekta_sso_token_guard_validate_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="password-fields">
-                <th scope="row">Token Endpoint URL</th>
+                <th scope="row">آدرس دریافت توکن</th>
                 <td><input type="text" name="yekta_sso_password_guard_token_endpoint" value="<?php echo esc_attr(get_option('yekta_sso_password_guard_token_endpoint')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="password-fields">
-                <th scope="row">Secret Key</th>
+                <th scope="row">کلید مخفی</th>
                 <td><input type="text" name="yekta_sso_password_guard_secret_key" value="<?php echo esc_attr(get_option('yekta_sso_password_guard_secret_key')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="secret-fields">
-                <th scope="row">Token Endpoint URL</th>
+                <th scope="row">آدرس دریافت توکن</th>
                 <td><input type="text" name="yekta_sso_secret_guard_token_endpoint" value="<?php echo esc_attr(get_option('yekta_sso_secret_guard_token_endpoint')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="secret-fields">
-                <th scope="row">Secret Key</th>
+                <th scope="row">کلید مخفی</th>
                 <td><input type="text" name="yekta_sso_secret_guard_secret_key" value="<?php echo esc_attr(get_option('yekta_sso_secret_guard_secret_key')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">Redirect URL (after login)</th>
+                <th scope="row">آدرس بازگشت (پس از ورود)</th>
                 <td><input type="text" name="yekta_sso_token_guard_redirect_url" value="<?php echo esc_attr(get_option('yekta_sso_token_guard_redirect_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="password-fields">
-                <th scope="row">Redirect URL (after login)</th>
+                <th scope="row">آدرس بازگشت (پس از ورود)</th>
                 <td><input type="text" name="yekta_sso_password_guard_redirect_url" value="<?php echo esc_attr(get_option('yekta_sso_password_guard_redirect_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="secret-fields">
-                <th scope="row">Redirect URL (after login)</th>
+                <th scope="row">آدرس بازگشت (پس از ورود)</th>
                 <td><input type="text" name="yekta_sso_secret_guard_redirect_url" value="<?php echo esc_attr(get_option('yekta_sso_secret_guard_redirect_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">Logout URL</th>
+                <th scope="row">آدرس خروج</th>
                 <td><input type="text" name="yekta_sso_token_guard_logout_url" value="<?php echo esc_attr(get_option('yekta_sso_token_guard_logout_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="password-fields">
-                <th scope="row">Logout URL</th>
+                <th scope="row">آدرس خروج</th>
                 <td><input type="text" name="yekta_sso_password_guard_logout_url" value="<?php echo esc_attr(get_option('yekta_sso_password_guard_logout_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="secret-fields">
-                <th scope="row">Logout URL</th>
+                <th scope="row">آدرس خروج</th>
                 <td><input type="text" name="yekta_sso_secret_guard_logout_url" value="<?php echo esc_attr(get_option('yekta_sso_secret_guard_logout_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">Public Key</th>
+                <th scope="row">کلید عمومی</th>
                 <td><textarea name="yekta_sso_token_guard_public_key" rows="4" style="width: 100%;"><?php echo esc_textarea(get_option('yekta_sso_token_guard_public_key')); ?></textarea></td>
             </tr>
             <tr valign="top" class="password-fields">
-                <th scope="row">Public Key</th>
+                <th scope="row">کلید عمومی</th>
                 <td><textarea name="yekta_sso_password_guard_public_key" rows="4" style="width: 100%;"><?php echo esc_textarea(get_option('yekta_sso_password_guard_public_key')); ?></textarea></td>
             </tr>
             <tr valign="top" class="secret-fields">
-                <th scope="row">Public Key</th>
+                <th scope="row">کلید عمومی</th>
                 <td><textarea name="yekta_sso_secret_guard_public_key" rows="4" style="width: 100%;"><?php echo esc_textarea(get_option('yekta_sso_secret_guard_public_key')); ?></textarea></td>
             </tr>
             <tr valign="top" class="token-fields">
-                <th scope="row">User Info URL</th>
+                <th scope="row">آدرس اطلاعات کاربر</th>
                 <td><input type="text" name="yekta_sso_token_guard_userinfo_url" value="<?php echo esc_attr(get_option('yekta_sso_token_guard_userinfo_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="password-fields">
-                <th scope="row">User Info URL</th>
+                <th scope="row">آدرس اطلاعات کاربر</th>
                 <td><input type="text" name="yekta_sso_password_guard_userinfo_url" value="<?php echo esc_attr(get_option('yekta_sso_password_guard_userinfo_url')); ?>" style="width: 100%;" /></td>
             </tr>
             <tr valign="top" class="secret-fields">
-                <th scope="row">User Info URL</th>
+                <th scope="row">آدرس اطلاعات کاربر</th>
                 <td><input type="text" name="yekta_sso_secret_guard_userinfo_url" value="<?php echo esc_attr(get_option('yekta_sso_secret_guard_userinfo_url')); ?>" style="width: 100%;" /></td>
             </tr>
         </table>

--- a/views/pages/sso-users.view.php
+++ b/views/pages/sso-users.view.php
@@ -1,0 +1,83 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+global $wpdb;
+$paged = max(1, intval($_GET['paged'] ?? 1));
+$per_page = 20;
+$offset = ($paged - 1) * $per_page;
+
+$user_query = new WP_User_Query([
+    'meta_key'   => 'sso_global_id',
+    'number'     => $per_page,
+    'offset'     => $offset,
+]);
+$users = $user_query->get_results();
+$total_users = $user_query->get_total();
+
+$audit_table = $wpdb->prefix . 'yekta_audit';
+$today = current_time('Y-m-d');
+$todays_logins = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$audit_table} WHERE type=%s AND DATE(created_at)=%s", 'login', $today));
+$todays_creations = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$audit_table} WHERE type=%s AND DATE(created_at)=%s", 'created', $today));
+$total_pages = ceil($total_users / $per_page);
+?>
+<div class="wrap">
+    <h1>کاربران SSO</h1>
+    <p>ورودهای امروز: <?php echo $todays_logins; ?> - کاربران جدید امروز: <?php echo $todays_creations; ?></p>
+    <table class="widefat fixed">
+        <thead>
+            <tr>
+                <th>نام کاربری</th>
+                <th>نام نمایشی</th>
+                <th>ایمیل</th>
+                <th>عملیات</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($users as $user): ?>
+                <tr>
+                    <td><?php echo esc_html($user->user_login); ?></td>
+                    <td><?php echo esc_html($user->display_name); ?></td>
+                    <td><?php echo esc_html($user->user_email); ?></td>
+                    <td><button class="button yekta-user-info-btn" data-id="<?php echo $user->ID; ?>">نمایش اطلاعات</button></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <div class="tablenav">
+        <div class="tablenav-pages">
+            <?php
+            echo paginate_links([
+                'base'      => add_query_arg('paged','%#%'),
+                'format'    => '',
+                'prev_text' => '«',
+                'next_text' => '»',
+                'total'     => $total_pages,
+                'current'   => $paged,
+            ]);
+            ?>
+        </div>
+    </div>
+    <div id="yekta-user-info-modal" style="display:none;position:fixed;top:10%;left:50%;transform:translateX(-50%);background:#fff;border:1px solid #ccc;padding:20px;max-width:600px;max-height:80%;overflow:auto;z-index:10000;">
+        <button id="yekta-close-modal" class="button">بستن</button>
+        <pre id="yekta-user-info-content" style="white-space:pre-wrap"></pre>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+    const modal=document.getElementById('yekta-user-info-modal');
+    const close=document.getElementById('yekta-close-modal');
+    const content=document.getElementById('yekta-user-info-content');
+    document.querySelectorAll('.yekta-user-info-btn').forEach(btn=>{
+        btn.addEventListener('click',function(){
+            const id=this.dataset.id;
+            modal.style.display='block';
+            content.textContent='در حال دریافت...';
+            fetch(ajaxurl+'?action=yekta_get_user_info&user_id='+id)
+                .then(r=>r.json())
+                .then(d=>{content.textContent=JSON.stringify(d,null,2);})
+                .catch(()=>{content.textContent='خطا در دریافت اطلاعات';});
+        });
+    });
+    close.addEventListener('click',()=>{modal.style.display='none';});
+});
+</script>


### PR DESCRIPTION
## Summary
- Persian translation for README with explanation of new `کاربران SSO` admin page
- keep audit table creation in AppServiceProvider
- user actions logged via `yekta_audit_log`
- admin page lists SSO users and fetches details via AJAX

## Testing
- `php -l Kernel/Auth/Guards/TokenSSOGuard.php`
- `php -l src/Helpers/helper.php`
- `php -l src/Providers/AppServiceProvider.php`
- `php -l src/Providers/PanelServiceProvider.php`
- `php -l views/pages/settings.view.php`
- `php -l views/pages/sso-users.view.php`


------
https://chatgpt.com/codex/tasks/task_e_6867dec206388327a43f9524b557ddfd